### PR TITLE
[#5] Auth signup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,15 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
+    // send mail
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+    // thymeleaf
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+    implementation 'nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect'
+
+    // save temp code
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
     // Bcrypt
     implementation 'com.password4j:password4j:1.8.2'
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,3 +16,11 @@ services:
     # volumes:
     #   - ~/workspace/db/data/:/var/lib/postgresql/data/
     restart: always
+
+  redis:
+    image: redis:latest
+    ports:
+      - "6379:6379"
+    environment:
+      - REDIS_PASSWORD=1234
+    restart: always

--- a/src/main/generated/csulb/mingle/domain/user/entity/QUser.java
+++ b/src/main/generated/csulb/mingle/domain/user/entity/QUser.java
@@ -28,21 +28,13 @@ public class QUser extends EntityPathBase<User> {
 
     public final StringPath firstname = createString("firstname");
 
-    public final DatePath<java.time.LocalDate> graduationYear = createDate("graduationYear", java.time.LocalDate.class);
-
     public final NumberPath<Long> id = createNumber("id", Long.class);
 
     public final StringPath lastname = createString("lastname");
 
-    public final StringPath major = createString("major");
-
-    public final StringPath minor = createString("minor");
-
     public final StringPath password = createString("password");
 
     public final DateTimePath<java.time.LocalDateTime> passwordChangedAt = createDateTime("passwordChangedAt", java.time.LocalDateTime.class);
-
-    public final StringPath studentId = createString("studentId");
 
     public final StringPath username = createString("username");
 

--- a/src/main/generated/csulb/mingle/domain/user/entity/QUser.java
+++ b/src/main/generated/csulb/mingle/domain/user/entity/QUser.java
@@ -1,0 +1,62 @@
+package csulb.mingle.domain.user.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QUser is a Querydsl query type for User
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QUser extends EntityPathBase<User> {
+
+    private static final long serialVersionUID = 1122880016L;
+
+    public static final QUser user = new QUser("user");
+
+    public final csulb.mingle.global.common.entity.QBaseTimeEntity _super = new csulb.mingle.global.common.entity.QBaseTimeEntity(this);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
+
+    public final StringPath email = createString("email");
+
+    public final StringPath firstname = createString("firstname");
+
+    public final DatePath<java.time.LocalDate> graduationYear = createDate("graduationYear", java.time.LocalDate.class);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath lastname = createString("lastname");
+
+    public final StringPath major = createString("major");
+
+    public final StringPath minor = createString("minor");
+
+    public final StringPath password = createString("password");
+
+    public final DateTimePath<java.time.LocalDateTime> passwordChangedAt = createDateTime("passwordChangedAt", java.time.LocalDateTime.class);
+
+    public final StringPath studentId = createString("studentId");
+
+    public final StringPath username = createString("username");
+
+    public QUser(String variable) {
+        super(User.class, forVariable(variable));
+    }
+
+    public QUser(Path<? extends User> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QUser(PathMetadata metadata) {
+        super(User.class, metadata);
+    }
+
+}
+

--- a/src/main/generated/csulb/mingle/global/common/entity/QBaseTimeEntity.java
+++ b/src/main/generated/csulb/mingle/global/common/entity/QBaseTimeEntity.java
@@ -1,0 +1,37 @@
+package csulb.mingle.global.common.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QBaseTimeEntity is a Querydsl query type for BaseTimeEntity
+ */
+@Generated("com.querydsl.codegen.DefaultSupertypeSerializer")
+public class QBaseTimeEntity extends EntityPathBase<BaseTimeEntity> {
+
+    private static final long serialVersionUID = -1618131161L;
+
+    public static final QBaseTimeEntity baseTimeEntity = new QBaseTimeEntity("baseTimeEntity");
+
+    public final DateTimePath<java.time.LocalDateTime> createdAt = createDateTime("createdAt", java.time.LocalDateTime.class);
+
+    public QBaseTimeEntity(String variable) {
+        super(BaseTimeEntity.class, forVariable(variable));
+    }
+
+    public QBaseTimeEntity(Path<? extends BaseTimeEntity> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QBaseTimeEntity(PathMetadata metadata) {
+        super(BaseTimeEntity.class, metadata);
+    }
+
+}
+

--- a/src/main/java/csulb/mingle/CsulBmingleApplication.java
+++ b/src/main/java/csulb/mingle/CsulBmingleApplication.java
@@ -2,8 +2,10 @@ package csulb.mingle;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class CsulBmingleApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/csulb/mingle/domain/auth/controller/AuthController.java
+++ b/src/main/java/csulb/mingle/domain/auth/controller/AuthController.java
@@ -1,0 +1,47 @@
+package csulb.mingle.domain.auth.controller;
+
+import csulb.mingle.domain.auth.dto.request.SendEmailRequest;
+import csulb.mingle.domain.auth.service.AuthService;
+import csulb.mingle.domain.auth.service.EmailService;
+import csulb.mingle.domain.auth.dto.request.SignUpRequest;
+import csulb.mingle.domain.auth.dto.response.SignupResponse;
+import csulb.mingle.global.common.dto.response.ResponseMessage;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+//    private final AuthService authService;
+    private final EmailService emailService;
+
+    @PostMapping("/email/verification-request")
+    public ResponseEntity<ResponseMessage> requestVerification(@Valid @RequestBody SendEmailRequest request) {
+        emailService.sendVerificationEmail(request.email());
+        ResponseMessage message = new ResponseMessage(null, HttpStatus.OK.value());
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(message);
+    }
+
+//    @PostMapping("/email/verify")
+//    public ResponseEntity<ResponseMessage> verifyEmail(@RequestBody VerifyEmailRequest request) {
+//        authService.verifyEmail(request);
+//        return ResponseEntity.ok().build();
+//    }
+
+//    @PostMapping("/signup")
+//    public ResponseEntity<ResponseMessage> signup(@Valid @RequestBody SignUpRequest request) {
+//        SignupResponse response = authService.signup(request);
+//        ResponseMessage message = new ResponseMessage(response, HttpStatus.CREATED.value());
+//        return ResponseEntity.status(HttpStatus.CREATED)
+//                .body(message);
+//    }
+}

--- a/src/main/java/csulb/mingle/domain/auth/controller/AuthController.java
+++ b/src/main/java/csulb/mingle/domain/auth/controller/AuthController.java
@@ -43,11 +43,12 @@ public class AuthController {
                 .body(message);
     }
 
-//    @PostMapping("/signup")
-//    public ResponseEntity<ResponseMessage> signup(@Valid @RequestBody SignUpRequest request) {
-//        SignupResponse response = authService.signup(request);
-//        ResponseMessage message = new ResponseMessage(response, HttpStatus.CREATED.value());
-//        return ResponseEntity.status(HttpStatus.CREATED)
-//                .body(message);
-//    }
+    @PostMapping("/signup")
+    public ResponseEntity<ResponseMessage> signup(@Valid @RequestBody SignUpRequest request) {
+        SignupResponse response = authService.signup(request);
+
+        ResponseMessage message = new ResponseMessage(response, HttpStatus.CREATED.value());
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(message);
+    }
 }

--- a/src/main/java/csulb/mingle/domain/auth/controller/AuthController.java
+++ b/src/main/java/csulb/mingle/domain/auth/controller/AuthController.java
@@ -1,6 +1,8 @@
 package csulb.mingle.domain.auth.controller;
 
 import csulb.mingle.domain.auth.dto.request.SendEmailRequest;
+import csulb.mingle.domain.auth.dto.request.VerifyEmailRequest;
+import csulb.mingle.domain.auth.dto.response.VerifyEmailResponse;
 import csulb.mingle.domain.auth.service.AuthService;
 import csulb.mingle.domain.auth.service.EmailService;
 import csulb.mingle.domain.auth.dto.request.SignUpRequest;
@@ -20,22 +22,26 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class AuthController {
 
-//    private final AuthService authService;
+    private final AuthService authService;
     private final EmailService emailService;
 
     @PostMapping("/email/verification-request")
     public ResponseEntity<ResponseMessage> requestVerification(@Valid @RequestBody SendEmailRequest request) {
         emailService.sendVerificationEmail(request.email());
+
         ResponseMessage message = new ResponseMessage(null, HttpStatus.OK.value());
         return ResponseEntity.status(HttpStatus.OK)
                 .body(message);
     }
 
-//    @PostMapping("/email/verify")
-//    public ResponseEntity<ResponseMessage> verifyEmail(@RequestBody VerifyEmailRequest request) {
-//        authService.verifyEmail(request);
-//        return ResponseEntity.ok().build();
-//    }
+    @PostMapping("/email/verify")
+    public ResponseEntity<ResponseMessage> verifyEmail(@Valid @RequestBody VerifyEmailRequest request) {
+        VerifyEmailResponse response = authService.verifyEmail(request);
+
+        ResponseMessage message = new ResponseMessage(response, HttpStatus.OK.value());
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(message);
+    }
 
 //    @PostMapping("/signup")
 //    public ResponseEntity<ResponseMessage> signup(@Valid @RequestBody SignUpRequest request) {

--- a/src/main/java/csulb/mingle/domain/auth/dto/request/SendEmailRequest.java
+++ b/src/main/java/csulb/mingle/domain/auth/dto/request/SendEmailRequest.java
@@ -1,0 +1,15 @@
+package csulb.mingle.domain.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+public record SendEmailRequest(
+//        @Pattern(regexp = EMAIL_FORMAT, message = "Please enter your school account email.")
+        @NotBlank(message = "Please enter your email.")
+        @NotNull(message = "Please enter your email.")
+        String email
+) {
+    private static final String EMAIL_FORMAT = "^[a-zA-Z0-9._%+-]+@student\\.csulb\\.edu$";
+
+}

--- a/src/main/java/csulb/mingle/domain/auth/dto/request/SignUpRequest.java
+++ b/src/main/java/csulb/mingle/domain/auth/dto/request/SignUpRequest.java
@@ -1,0 +1,49 @@
+package csulb.mingle.domain.auth.dto.request;
+
+import csulb.mingle.domain.user.entity.User;
+import jakarta.validation.constraints.*;
+
+public record SignUpRequest(
+
+        @Pattern(regexp = NAME_FORMAT, message = "Please enter your name without blank and special character.")
+        @Size(min = 1, max = 50, message = "The name length should be between 1 and 50.")
+        @NotBlank(message = "Please enter your name.")
+        @NotNull(message = "Please enter your name.")
+        String firstname,
+
+        @Pattern(regexp = NAME_FORMAT, message = "Please enter your name without blank and special character.")
+        @Size(min = 1, max = 50, message = "The name length should be between 1 and 50.")
+        @NotBlank(message = "Please enter your name.")
+        @NotNull(message = "Please enter your name.")
+        String lastname,
+
+        @Size(min = 1, max = 30, message = "The username length should be between 1 and 30.")
+        @NotBlank(message = "Please enter your username.")
+        @NotNull(message = "Please enter your username.")
+        String username,
+
+//        @Pattern(regexp = EMAIL_FORMAT, message = "Please enter your school account email.")
+        @NotBlank(message = "Please enter your email.")
+        @NotNull(message = "Please enter your email.")
+        String email,
+
+        @Pattern(regexp = PASSWORD_FORMAT, message = "Password conditions do not match.")
+        @NotBlank(message = "Please enter your password.")
+        @NotNull(message = "Please enter your password.")
+        String password
+) {
+    private static final String NAME_FORMAT = "^[a-zA-Z]+$";
+    private static final String EMAIL_FORMAT = "^[a-zA-Z0-9._%+-]+@student\\.csulb\\.edu$";
+    private static final String PASSWORD_FORMAT = "^(?=(.*[a-z]){1,})(?=(.*[A-Z]){1,})(?=(.*\\d){1,})(?=(.*[\\W_]){1,})(?!.*\\s).{8,16}$";
+
+    public User toUser(String encodedPassword) {
+
+        return User.builder()
+                .firstname(this.firstname)
+                .lastname(this.lastname)
+                .username(this.username)
+                .email(this.email)
+                .password(encodedPassword)
+                .build();
+    }
+}

--- a/src/main/java/csulb/mingle/domain/auth/dto/request/VerifyEmailRequest.java
+++ b/src/main/java/csulb/mingle/domain/auth/dto/request/VerifyEmailRequest.java
@@ -1,0 +1,22 @@
+package csulb.mingle.domain.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record VerifyEmailRequest(
+//        @Pattern(regexp = EMAIL_FORMAT, message = "Please enter your school account email.")
+        @NotBlank(message = "Please enter your email.")
+        @NotNull(message = "Please enter your email.")
+        String email,
+
+        @Pattern(regexp = VERIFICATION_CODE_FORMAT, message = "Verification code must be exactly 6 digits.")
+        @NotBlank(message = "Please enter the verification code.")
+        @NotNull(message = "Please enter your verification code.")
+        String verificationCode
+
+) {
+        private static final String EMAIL_FORMAT = "^[a-zA-Z0-9._%+-]+@student\\.csulb\\.edu$";
+        public static final String VERIFICATION_CODE_FORMAT = "^[0-9]{6}$";
+}

--- a/src/main/java/csulb/mingle/domain/auth/dto/response/SignupResponse.java
+++ b/src/main/java/csulb/mingle/domain/auth/dto/response/SignupResponse.java
@@ -1,0 +1,17 @@
+package csulb.mingle.domain.auth.dto.response;
+
+public record SignupResponse(
+        String firstname,
+        String lastname,
+        String username,
+        String email
+) {
+    public static SignupResponse of( String firstname,  String lastname,  String username, String email) {
+        return new SignupResponse(
+                firstname,
+                lastname,
+                username,
+                email
+        );
+    }
+}

--- a/src/main/java/csulb/mingle/domain/auth/dto/response/VerifyEmailResponse.java
+++ b/src/main/java/csulb/mingle/domain/auth/dto/response/VerifyEmailResponse.java
@@ -1,10 +1,11 @@
 package csulb.mingle.domain.auth.dto.response;
 
-import lombok.Builder;
-
 public record VerifyEmailResponse(
 
         String email,
         boolean isSuccess
 ) {
+    public static VerifyEmailResponse from(String email, boolean isSuccess) {
+        return new VerifyEmailResponse(email, isSuccess);
+    }
 }

--- a/src/main/java/csulb/mingle/domain/auth/dto/response/VerifyEmailResponse.java
+++ b/src/main/java/csulb/mingle/domain/auth/dto/response/VerifyEmailResponse.java
@@ -1,0 +1,10 @@
+package csulb.mingle.domain.auth.dto.response;
+
+import lombok.Builder;
+
+public record VerifyEmailResponse(
+
+        String email,
+        boolean isSuccess
+) {
+}

--- a/src/main/java/csulb/mingle/domain/auth/exception/AuthException.java
+++ b/src/main/java/csulb/mingle/domain/auth/exception/AuthException.java
@@ -1,0 +1,16 @@
+package csulb.mingle.domain.auth.exception;
+
+import csulb.mingle.global.error.exception.BaseException;
+import csulb.mingle.global.error.exception.BaseExceptionType;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class AuthException extends BaseException {
+
+    private final BaseExceptionType exceptionType;
+
+    @Override
+    public BaseExceptionType getExceptionType() {
+        return exceptionType;
+    }
+}

--- a/src/main/java/csulb/mingle/domain/auth/exception/AuthExceptionType.java
+++ b/src/main/java/csulb/mingle/domain/auth/exception/AuthExceptionType.java
@@ -5,7 +5,9 @@ import org.springframework.http.HttpStatus;
 
 public enum AuthExceptionType implements BaseExceptionType {
 
-    EMAIL_SEND_FAILED(500, HttpStatus.INTERNAL_SERVER_ERROR, "failed to send email.");
+    EMAIL_SEND_FAILED(500, HttpStatus.INTERNAL_SERVER_ERROR, "failed to send email."),
+    EXPIRED_VERIFICATION_CODE(401, HttpStatus.UNAUTHORIZED, "verification code expired."),
+    WRONG_VERIFICATION_CODE(400, HttpStatus.BAD_REQUEST, "verification code is wrong.");
 
     private final int statusCode;
     private final HttpStatus httpStatus;

--- a/src/main/java/csulb/mingle/domain/auth/exception/AuthExceptionType.java
+++ b/src/main/java/csulb/mingle/domain/auth/exception/AuthExceptionType.java
@@ -1,0 +1,34 @@
+package csulb.mingle.domain.auth.exception;
+
+import csulb.mingle.global.error.exception.BaseExceptionType;
+import org.springframework.http.HttpStatus;
+
+public enum AuthExceptionType implements BaseExceptionType {
+
+    EMAIL_SEND_FAILED(500, HttpStatus.INTERNAL_SERVER_ERROR, "failed to send email.");
+
+    private final int statusCode;
+    private final HttpStatus httpStatus;
+    private final String errorMessage;
+
+    AuthExceptionType(int statusCode, HttpStatus httpStatus, String errorMessage) {
+        this.statusCode = statusCode;
+        this.httpStatus = httpStatus;
+        this.errorMessage = errorMessage;
+    }
+
+    @Override
+    public int getStatusCode() {
+        return statusCode;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+}

--- a/src/main/java/csulb/mingle/domain/auth/service/AuthService.java
+++ b/src/main/java/csulb/mingle/domain/auth/service/AuthService.java
@@ -1,0 +1,68 @@
+package csulb.mingle.domain.auth.service;
+
+import csulb.mingle.domain.auth.dto.request.VerifyEmailRequest;
+import csulb.mingle.domain.auth.dto.response.VerifyEmailResponse;
+import csulb.mingle.domain.auth.exception.AuthException;
+import csulb.mingle.domain.auth.exception.AuthExceptionType;
+import csulb.mingle.domain.user.repository.UserRepository;
+import csulb.mingle.global.util.redis.RedisUtil;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import static csulb.mingle.global.util.redis.RedisConstants.*;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AuthService {
+
+    public static final String VERIFIED_EMAIL = "verified:";
+
+    private final UserRepository userRepository;
+    private final RedisUtil redisUtil;
+
+//    public SignupResponse signup(SignUpRequest request) {
+//
+//        validateVerifiedEmail(request);
+//
+//        String encodedPassword = bcryptService.encodeBcrypt(request.getPassword());
+//        User user = request.toUser(encodedPassword);
+//        userRepository.save(user);
+//
+//        // 인증 정보 삭제
+//        redisTemplate.delete("verified:" + request.getEmail());
+//
+//        return SignupResponse.from(user);
+//    }
+
+    public VerifyEmailResponse verifyEmail(VerifyEmailRequest request) {
+        String storedCode = redisUtil.getData(UNVERIFIED_PREFIX + request.email());
+        verifyUnexpiredCode(storedCode);
+        verifyRightCode(request, storedCode);
+        redisUtil.setDataExpire(VERIFIED_PREFIX + request.email(), "true", VERIFIED_USER_DURATION_MINUTES);
+        return new VerifyEmailResponse(request.email(), true);
+    }
+
+    private void verifyUnexpiredCode(String storedCode) {
+        if (storedCode == null) {
+            throw new AuthException(AuthExceptionType.EXPIRED_VERIFICATION_CODE);
+        }
+    }
+
+    private void verifyRightCode(VerifyEmailRequest request, String storedCode) {
+        if (!storedCode.equals(request.verificationCode())) {
+            throw new AuthException(AuthExceptionType.WRONG_VERIFICATION_CODE);
+        }
+    }
+
+
+//    private void validateVerifiedEmail(SignUpRequest request) {
+//        String verified = redisTemplate.opsForValue().get(VERIFIED_EMAIL + request.email());
+//
+//        if (verified == null) {
+//            throw new UserException(UserExceptionType.NEED_VERIFIED_EMAIL);
+//        }
+//    }
+
+}

--- a/src/main/java/csulb/mingle/domain/auth/service/BcryptService.java
+++ b/src/main/java/csulb/mingle/domain/auth/service/BcryptService.java
@@ -1,0 +1,16 @@
+package csulb.mingle.domain.auth.service;
+
+import com.password4j.Password;
+import org.springframework.stereotype.Service;
+
+@Service
+public class BcryptService {
+
+    public String encodeBcrypt(String plainPassword) {
+        return Password.hash(plainPassword).withBcrypt().getResult();
+    }
+
+    public boolean matchBcrypt(String plainPassword, String HashedPassword){
+        return Password.check(plainPassword, HashedPassword).withBcrypt();
+    }
+}

--- a/src/main/java/csulb/mingle/domain/auth/service/EmailService.java
+++ b/src/main/java/csulb/mingle/domain/auth/service/EmailService.java
@@ -1,0 +1,78 @@
+package csulb.mingle.domain.auth.service;
+
+import csulb.mingle.domain.auth.exception.AuthException;
+import csulb.mingle.domain.auth.exception.AuthExceptionType;
+import csulb.mingle.domain.user.exception.UserException;
+import csulb.mingle.domain.user.exception.UserExceptionType;
+import csulb.mingle.domain.user.repository.UserRepository;
+import csulb.mingle.global.error.exception.BaseException;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+
+import java.security.SecureRandom;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class EmailService {
+
+    public static final int RANDOM_CODE_LENGTH = 6;
+
+    private final JavaMailSender emailSender;
+    private final SpringTemplateEngine templateEngine;
+    private final UserRepository userRepository;
+//    private final RedisUtil redisUtil;
+
+
+    public void sendVerificationEmail(String email) {
+        validateNonExistUser(email);
+        try {
+            String verificationCode = createRandomCode();
+            MimeMessage mimeMessage = createEmailForm(email, verificationCode);
+            emailSender.send(mimeMessage);
+        } catch (MessagingException e) {
+            throw new AuthException(AuthExceptionType.EMAIL_SEND_FAILED);
+        }
+    }
+
+    private void validateNonExistUser(String email) {
+        if (userRepository.existsUserByEmail(email)) {
+            throw new UserException(UserExceptionType.USER_ALREADY_EXIST);
+        }
+    }
+
+    private String createRandomCode() {
+        SecureRandom secureRandom = new SecureRandom();
+        StringBuilder builder = new StringBuilder(RANDOM_CODE_LENGTH);
+
+        for (int i = 0; i < RANDOM_CODE_LENGTH; i++) {
+            builder.append(secureRandom.nextInt(10));
+        }
+        return builder.toString();
+    }
+
+    private MimeMessage createEmailForm(String email, String verificationCode) throws MessagingException {
+        MimeMessage message = emailSender.createMimeMessage();
+
+        MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+
+        helper.setTo(email);
+        helper.setSubject("Sign up for MINGLE - Email Verification");
+        String content = setContext(verificationCode);
+        helper.setText(content, true);
+        return message;
+    }
+
+    private String setContext(String verificationCode) {
+        Context context = new Context();
+        context.setVariable("verificationCode", verificationCode);
+        return templateEngine.process("mail/verification-email",context);
+    }
+}

--- a/src/main/java/csulb/mingle/domain/user/entity/User.java
+++ b/src/main/java/csulb/mingle/domain/user/entity/User.java
@@ -39,17 +39,17 @@ public class User extends BaseTimeEntity {
     @Column(nullable = false, unique = true, length = 30)
     private String username;
 
-    @Column(nullable = false, length = 50)
-    private String major;
-
-    @Column(nullable = false, length = 50)
-    private String minor;
-
-    @Column(name = "graduation_year", nullable = false)
-    private LocalDate graduationYear;
-
-    @Column(name = "student_id", nullable = false, length = 50)
-    private String studentId;
+//    @Column(nullable = false, length = 50)
+//    private String major;
+//
+//    @Column(nullable = false, length = 50)
+//    private String minor;
+//
+//    @Column(name = "graduation_year", nullable = false)
+//    private LocalDate graduationYear;
+//
+//    @Column(name = "student_id", nullable = false, length = 50)
+//    private String studentId;
 
     @Column(name = "password_changed_at")
     private LocalDateTime passwordChangedAt;
@@ -62,10 +62,10 @@ public class User extends BaseTimeEntity {
         this.firstname = firstname;
         this.lastname = lastname;
         this.username = username;
-        this.major = major;
-        this.minor = minor;
-        this.graduationYear = graduationYear;
-        this.studentId = studentId;
+//        this.major = major;
+//        this.minor = minor;
+//        this.graduationYear = graduationYear;
+//        this.studentId = studentId;
         this.passwordChangedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/csulb/mingle/domain/user/entity/User.java
+++ b/src/main/java/csulb/mingle/domain/user/entity/User.java
@@ -1,0 +1,55 @@
+package csulb.mingle.domain.user.entity;
+
+import csulb.mingle.global.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SoftDelete;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+@SoftDelete(columnName = "is_deleted")
+@Table(name = "users")
+public class User extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    @Column(unique = true, nullable = false, length = 128)
+    private String email;
+
+    @Column(nullable = false, length = 64)
+    private String password;
+
+    @Column(nullable = false, length = 50)
+    private String firstname;
+
+    @Column(nullable = false, length = 50)
+    private String lastname;
+
+    @Column(nullable = false, unique = true, length = 30)
+    private String username;
+
+    @Column(nullable = false, length = 50)
+    private String major;
+
+    @Column(nullable = false, length = 50)
+    private String minor;
+
+    @Column(name = "graduation_year", nullable = false)
+    private LocalDate graduationYear;
+
+    @Column(name = "student_id", nullable = false, length = 50)
+    private String studentId;
+
+    @Column(name = "password_changed_at")
+    private LocalDateTime passwordChangedAt;
+}

--- a/src/main/java/csulb/mingle/domain/user/entity/User.java
+++ b/src/main/java/csulb/mingle/domain/user/entity/User.java
@@ -2,6 +2,7 @@ package csulb.mingle.domain.user.entity;
 
 import csulb.mingle.global.common.entity.BaseTimeEntity;
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SoftDelete;
@@ -52,4 +53,19 @@ public class User extends BaseTimeEntity {
 
     @Column(name = "password_changed_at")
     private LocalDateTime passwordChangedAt;
+
+    @Builder
+
+    private User(String email, String password, String firstname, String lastname, String username, String major, String minor, LocalDate graduationYear, String studentId, LocalDateTime passwordChangedAt) {
+        this.email = email;
+        this.password = password;
+        this.firstname = firstname;
+        this.lastname = lastname;
+        this.username = username;
+        this.major = major;
+        this.minor = minor;
+        this.graduationYear = graduationYear;
+        this.studentId = studentId;
+        this.passwordChangedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/csulb/mingle/domain/user/exception/UserException.java
+++ b/src/main/java/csulb/mingle/domain/user/exception/UserException.java
@@ -1,0 +1,16 @@
+package csulb.mingle.domain.user.exception;
+
+import csulb.mingle.global.error.exception.BaseException;
+import csulb.mingle.global.error.exception.BaseExceptionType;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class UserException extends BaseException {
+
+    private final BaseExceptionType exceptionType;
+
+    @Override
+    public BaseExceptionType getExceptionType() {
+        return exceptionType;
+    }
+}

--- a/src/main/java/csulb/mingle/domain/user/exception/UserExceptionType.java
+++ b/src/main/java/csulb/mingle/domain/user/exception/UserExceptionType.java
@@ -1,0 +1,35 @@
+package csulb.mingle.domain.user.exception;
+
+import csulb.mingle.global.error.exception.BaseExceptionType;
+import org.springframework.http.HttpStatus;
+
+public enum UserExceptionType implements BaseExceptionType {
+
+    USER_ALREADY_EXIST(409, HttpStatus.CONFLICT, "User account that already exists."),
+    NEED_VERIFIED_EMAIL(401, HttpStatus.UNAUTHORIZED, "E-mail authentication required.");
+
+    private final int statusCode;
+    private final HttpStatus httpStatus;
+    private final String errorMessage;
+
+    UserExceptionType(int statusCode, HttpStatus httpStatus, String errorMessage) {
+        this.statusCode = statusCode;
+        this.httpStatus = httpStatus;
+        this.errorMessage = errorMessage;
+    }
+
+    @Override
+    public int getStatusCode() {
+        return statusCode;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+}

--- a/src/main/java/csulb/mingle/domain/user/repository/UserJpaRepository.java
+++ b/src/main/java/csulb/mingle/domain/user/repository/UserJpaRepository.java
@@ -1,0 +1,11 @@
+package csulb.mingle.domain.user.repository;
+
+import csulb.mingle.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+
+public interface UserJpaRepository extends JpaRepository<User, Long> {
+
+    boolean existsUserByEmail(String userEmail);
+
+}

--- a/src/main/java/csulb/mingle/domain/user/repository/UserRepository.java
+++ b/src/main/java/csulb/mingle/domain/user/repository/UserRepository.java
@@ -7,4 +7,6 @@ import org.springframework.stereotype.Repository;
 public interface UserRepository {
 
     boolean existsUserByEmail(String userEmail);
+
+    void save(User user);
 }

--- a/src/main/java/csulb/mingle/domain/user/repository/UserRepository.java
+++ b/src/main/java/csulb/mingle/domain/user/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package csulb.mingle.domain.user.repository;
+
+import csulb.mingle.domain.user.entity.User;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository {
+
+    boolean existsUserByEmail(String userEmail);
+}

--- a/src/main/java/csulb/mingle/domain/user/repository/UserRepositoryImpl.java
+++ b/src/main/java/csulb/mingle/domain/user/repository/UserRepositoryImpl.java
@@ -1,5 +1,6 @@
 package csulb.mingle.domain.user.repository;
 
+import csulb.mingle.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -12,5 +13,10 @@ public class UserRepositoryImpl implements UserRepository {
     @Override
     public boolean existsUserByEmail(String userEmail) {
         return userJpaRepository.existsUserByEmail(userEmail);
+    }
+
+    @Override
+    public void save(User user) {
+        userJpaRepository.save(user);
     }
 }

--- a/src/main/java/csulb/mingle/domain/user/repository/UserRepositoryImpl.java
+++ b/src/main/java/csulb/mingle/domain/user/repository/UserRepositoryImpl.java
@@ -1,0 +1,16 @@
+package csulb.mingle.domain.user.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class UserRepositoryImpl implements UserRepository {
+
+    private final UserJpaRepository userJpaRepository;
+
+    @Override
+    public boolean existsUserByEmail(String userEmail) {
+        return userJpaRepository.existsUserByEmail(userEmail);
+    }
+}

--- a/src/main/java/csulb/mingle/global/common/entity/BaseTimeEntity.java
+++ b/src/main/java/csulb/mingle/global/common/entity/BaseTimeEntity.java
@@ -1,0 +1,21 @@
+package csulb.mingle.global.common.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+}

--- a/src/main/java/csulb/mingle/global/config/MailConfig.java
+++ b/src/main/java/csulb/mingle/global/config/MailConfig.java
@@ -1,0 +1,56 @@
+package csulb.mingle.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Configuration
+public class MailConfig {
+    @Value("${spring.mail.host}")
+    private String host;
+
+    @Value("${spring.mail.port}")
+    private int port;
+
+    @Value("${spring.mail.username}")
+    private String username;
+
+    @Value("${spring.mail.password}")
+    private String password;
+
+    @Value("${spring.mail.properties.mail.smtp.auth}")
+    private boolean auth;
+
+    @Value("${spring.mail.properties.mail.smtp.starttls.enable}")
+    private boolean starttlsEnable;
+
+    @Value("${spring.mail.properties.mail.smtp.timeout}")
+    private int timeout;
+
+    @Bean
+    public JavaMailSender javaMailSender() {
+
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+        mailSender.setHost(host);
+        mailSender.setPort(port);
+        mailSender.setUsername(username);
+        mailSender.setPassword(password);
+        mailSender.setJavaMailProperties(getMailProperties());
+
+        return mailSender;
+    }
+
+    private Properties getMailProperties() {
+
+        Properties props = new Properties();
+        props.put("mail.smtp.auth", auth);
+        props.put("mail.smtp.starttls.enable", starttlsEnable);
+        props.put("mail.smtp.timeout", timeout);
+
+        return props;
+    }
+}

--- a/src/main/java/csulb/mingle/global/config/RedisConfig.java
+++ b/src/main/java/csulb/mingle/global/config/RedisConfig.java
@@ -1,0 +1,31 @@
+package csulb.mingle.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+    @Value("${spring.redis.host}")
+    private String host;
+
+    @Value("${spring.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate() {
+        StringRedisTemplate redisTemplate = new StringRedisTemplate();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        return redisTemplate;
+    }
+}

--- a/src/main/java/csulb/mingle/global/util/redis/RedisConstants.java
+++ b/src/main/java/csulb/mingle/global/util/redis/RedisConstants.java
@@ -1,0 +1,12 @@
+package csulb.mingle.global.util.redis;
+
+public class RedisConstants {
+    public static final String UNVERIFIED_PREFIX = "unverified:";
+    public static final String VERIFIED_PREFIX = "verified:";
+    public static final long VERIFIED_CODE_DURATION_MINUTES = 10;
+    public static final long VERIFIED_USER_DURATION_MINUTES = 30;
+
+    private RedisConstants() {
+    }
+}
+

--- a/src/main/java/csulb/mingle/global/util/redis/RedisUtil.java
+++ b/src/main/java/csulb/mingle/global/util/redis/RedisUtil.java
@@ -1,0 +1,29 @@
+package csulb.mingle.global.util.redis;
+
+import jakarta.annotation.Resource;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@RequiredArgsConstructor
+@Service
+public class RedisUtil {
+
+    @Resource(name = "redisTemplate")
+    private ValueOperations<String, String> valueOperations;
+
+    public String getData(String key) {
+        return valueOperations.get(key);
+    }
+
+    public void setData(String key, String value) {
+        valueOperations.set(key, value);
+    }
+
+    public void setDataExpire(String key, String value, long duration) {
+        Duration expireDuration = Duration.ofMinutes(duration);
+        valueOperations.set(key, value, expireDuration);
+    }
+}

--- a/src/main/java/csulb/mingle/global/util/redis/RedisUtil.java
+++ b/src/main/java/csulb/mingle/global/util/redis/RedisUtil.java
@@ -26,4 +26,8 @@ public class RedisUtil {
         Duration expireDuration = Duration.ofMinutes(duration);
         valueOperations.set(key, value, expireDuration);
     }
+
+     public void deleteData(String key){
+        valueOperations.getOperations().delete(key);
+    }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -25,3 +25,6 @@ spring:
           timeout: 5000
           starttls:
             enable: true
+  redis:
+    host: localhost
+    port: 6379

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -12,3 +12,16 @@ spring:
     properties:
       hibernate:
         format_sql: true
+
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${mail.username}
+    password: ${mail.password}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          timeout: 5000
+          starttls:
+            enable: true

--- a/src/main/resources/templates/mail/verification-email.html
+++ b/src/main/resources/templates/mail/verification-email.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+
+<body>
+<div style='margin:20px;'>
+    <h1> Please enter your verification code in your Mingle app when prompted.</h1>
+    <br>
+    <p>This code will expire after 10 minutes.</p>
+    <br>
+
+    <div align="center" style="border:1px solid black; font-family:verdana;">
+        <h3 style="color:blue"> verification-code </h3>
+        <div style="font-size:130%" th:text="${verificationCode}"></div>
+    </div>
+    <br/>
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
## Description

> User 엔티티 생성 및 회원가입 기능 구현

## Changes

- redis db 도입으로 인한 `docker-compose.yml`수정, `build.gradle`에 의존성 추가
- 메일 인증으로 인한 spring-boot-starter-mail, thymeleaf `build.gradle`에 의존성 추가

## Comment

-  dto request/response key값 네이밍 컨벤션 정해야 할 것 같습니다!
- User 테이블 이름 postgres에서 user 예약어 이슈로 users로 테이블명 지정
- ‼️User 테이블 컬럼은 일단 한 곳에 다 모아두었는데요,,,분리가 필요하다고 생각드시면, 말씀해주세요! 
(현재 주석처리 해둔 부분은 일요일 회의 후 해제할 것 같습니다.)